### PR TITLE
Fix broken URLs in PHP recipes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -7,7 +7,7 @@ description: Learn how to configure the Lando LAMP recipe.
 
 While Lando [recipes](https://docs.lando.dev/config/recipes.html) set sane defaults so they work out of the box, they are also [configurable](https://docs.lando.dev/config/recipes.html#config).
 
-Here are the configuration options, set to the default values, for this recipe's [Landofile](https://docs.lando.dev/config/lando.html). If you are unsure about where this goes or what this means we *highly recommend* scanning the [recipes documentation](https://docs.lando.dev/config/recipes.html) to get a good handle on how the magicks work.
+Here are the configuration options, set to the default values, for this recipe's [Landofile](https://docs.lando.dev/config). If you are unsure about where this goes or what this means we *highly recommend* scanning the [recipes documentation](https://docs.lando.dev/config/recipes.html) to get a good handle on how the magicks work.
 
 ```yaml
 recipe: lamp
@@ -50,9 +50,9 @@ config:
 
 ## Choosing a database backend
 
-By default, this recipe will use the default version of our [mysql](https://docs.lando.devmysql.html) service as the database backend but you can also switch this to use [`mariadb`](https://docs.lando.devmariadb.html) or ['postgres'](https://docs.lando.devpostgres.html) instead. Note that you can also specify a version *as long as it is a version available for use with lando* for either `mysql`, `mariadb` or `postgres`.
+By default, this recipe will use the default version of our [mysql](https://docs.lando.dev/mysql) service as the database backend but you can also switch this to use [`mariadb`](https://docs.lando.dev/mariadb) or ['postgres'](https://docs.lando.dev/postgres) instead. Note that you can also specify a version *as long as it is a version available for use with lando* for either `mysql`, `mariadb` or `postgres`.
 
-If you are unsure about how to configure the `database`, we *highly recommend* you check out the [mysql](https://docs.lando.devmysql.html), [mariadb](https://docs.lando.devmariadb.html)and ['postgres'](https://docs.lando.devpostgres.html) services before you change the default.
+If you are unsure about how to configure the `database`, we *highly recommend* you check out the [mysql](https://docs.lando.dev/mysql), [mariadb](https://docs.lando.dev/mariadb)and ['postgres'](https://docs.lando.dev/postgres) services before you change the default.
 
 #### Using MySQL (default)
 
@@ -113,7 +113,7 @@ You may need to override our [default LAMP config](https://github.com/lando/lamp
 
 If you do this, you must use files that exist inside your application and express them relative to your project root as shown below:
 
-Note that the default files may change based on how you set both `ssl` and `via`. Also note that the `vhosts` and `server` config will be explicitly for `apache`. We *highly recommend* you check out the [apache](https://docs.lando.devapache.html#configuration) if you plan to use a custom `vhosts` or `server` config.
+Note that the default files may change based on how you set both `ssl` and `via`. Also note that the `vhosts` and `server` config will be explicitly for `apache`. We *highly recommend* you check out the [apache](https://docs.lando.dev/apache/config.html) if you plan to use a custom `vhosts` or `server` config.
 
 **A hypothetical project**
 


### PR DESCRIPTION
This fixes some broken or changed links.

Links to the various db recipes and the Apache recipe were broken. I've tested and updated the other URLs, too, and found a link to a config page that used to be an anchor tag on the same page.