### PR TITLE
Added init defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Added `defaults` to the `init` function.
+
 ## v1.8.1 - [December 9, 2024](https://github.com/lando/lamp/releases/tag/v1.8.1)
 
 * Removed unneeded `@lando/nginx` dependency

--- a/examples/lamp-init/README.md
+++ b/examples/lamp-init/README.md
@@ -75,6 +75,14 @@ lando php -v |grep "5.6"
 lando exec database -- mysql --version | grep "10.3"
 lando poweroff
 mv orig.lando.yml .lando.yml
+
+# Should have defaults in .lando.yml
+cd lamp
+cat .lando.yml | grep 'php: "7.4"'
+cat .lando.yml | grep "via: apache"
+cat .lando.yml | grep "xdebug: false"
+cat .lando.yml | grep "webroot: ."
+cat .lando.yml | grep "database: mysql"
 ```
 
 ## Destroy tests

--- a/inits/lamp.js
+++ b/inits/lamp.js
@@ -5,4 +5,11 @@
  */
 module.exports = {
   name: 'lamp',
+  defaults: {
+    via: 'apache',
+    php: '7.4',
+    database: 'mysql',
+    webroot: '.',
+    xdebug: false,
+  },
 };


### PR DESCRIPTION
### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [ ] I've updated this PR with the latest code from `main`
- [ ] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [ ] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
